### PR TITLE
Make swagger options configurable.

### DIFF
--- a/src/Lykke.Sdk/LykkeApplicationBuilderExtensions.cs
+++ b/src/Lykke.Sdk/LykkeApplicationBuilderExtensions.cs
@@ -58,7 +58,12 @@ namespace Lykke.Sdk
                 app.UseSwaggerUI(x =>
                 {
                     x.RoutePrefix = "swagger/ui";
-                    x.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+                    x.SwaggerEndpoint("/swagger/v1/swagger.json", options.ApiVersion);
+
+                    if (!string.IsNullOrWhiteSpace(options.SwaggerDocumentTitle))
+                    {
+                        x.DocumentTitle(options.SwaggerDocumentTitle);
+                    }
                 });
             }
             catch (Exception ex)
@@ -78,5 +83,5 @@ namespace Lykke.Sdk
                 throw;
             }
         }
-    }    
+    }
 }

--- a/src/Lykke.Sdk/LykkeApplicationBuilderExtensions.cs
+++ b/src/Lykke.Sdk/LykkeApplicationBuilderExtensions.cs
@@ -58,11 +58,11 @@ namespace Lykke.Sdk
                 app.UseSwaggerUI(x =>
                 {
                     x.RoutePrefix = "swagger/ui";
-                    x.SwaggerEndpoint("/swagger/v1/swagger.json", options.ApiVersion);
+                    x.SwaggerEndpoint("/swagger/v1/swagger.json", options.SwaggerOptions.ApiVersion);
 
-                    if (!string.IsNullOrWhiteSpace(options.SwaggerDocumentTitle))
+                    if (!string.IsNullOrWhiteSpace(options.SwaggerOptions.ApiTitle))
                     {
-                        x.DocumentTitle(options.SwaggerDocumentTitle);
+                        x.DocumentTitle(options.SwaggerOptions.ApiTitle);
                     }
                 });
             }

--- a/src/Lykke.Sdk/LykkeConfigurationOptions.cs
+++ b/src/Lykke.Sdk/LykkeConfigurationOptions.cs
@@ -13,9 +13,16 @@ namespace Lykke.Sdk
         /// <summary>Default error handler.</summary>
         public CreateErrorResponse DefaultErrorHandler { get; set; }
 
+        /// <summary>API version</summary>
+        public string ApiVersion { get; set; }
+
+        /// <summary>Document title displayed in Swagger UI.</summary>
+        public string SwaggerDocumentTitle { get; set; }
+
         internal LykkeConfigurationOptions()
         {
             DefaultErrorHandler = ex => ErrorResponse.Create("Technical problem");
+            ApiVersion = "v1";
         }
     }
 }

--- a/src/Lykke.Sdk/LykkeConfigurationOptions.cs
+++ b/src/Lykke.Sdk/LykkeConfigurationOptions.cs
@@ -13,16 +13,13 @@ namespace Lykke.Sdk
         /// <summary>Default error handler.</summary>
         public CreateErrorResponse DefaultErrorHandler { get; set; }
 
-        /// <summary>API version</summary>
-        public string ApiVersion { get; set; }
-
-        /// <summary>Document title displayed in Swagger UI.</summary>
-        public string SwaggerDocumentTitle { get; set; }
+        /// <summary>Lykke swagger options</summary>
+        public LykkeSwaggerOptions SwaggerOptions { get; set; }
 
         internal LykkeConfigurationOptions()
         {
             DefaultErrorHandler = ex => ErrorResponse.Create("Technical problem");
-            ApiVersion = "v1";
+            SwaggerOptions = new LykkeSwaggerOptions();
         }
     }
 }

--- a/src/Lykke.Sdk/LykkeServiceCollectionContainerBuilderExtensions.cs
+++ b/src/Lykke.Sdk/LykkeServiceCollectionContainerBuilderExtensions.cs
@@ -42,9 +42,9 @@ namespace Lykke.Sdk
 
             buildServiceOptions(serviceOptions);
 
-            if (string.IsNullOrWhiteSpace(serviceOptions.ApiTitle))
+            if (serviceOptions.SwaggerOptions == null)
             {
-                throw new ArgumentException("Api title must be provided.");
+                throw new ArgumentException("Swagger options must be provided.");
             }
 
             if (serviceOptions.Logs == null)
@@ -76,7 +76,9 @@ namespace Lykke.Sdk
 
             services.AddSwaggerGen(options =>
             {
-                options.DefaultLykkeConfiguration("v1", serviceOptions.ApiTitle);
+                options.DefaultLykkeConfiguration(
+                    serviceOptions.SwaggerOptions.ApiVersion ?? throw new ArgumentException($"{nameof(LykkeSwaggerOptions)}.{nameof(LykkeSwaggerOptions.ApiVersion)}"), 
+                    serviceOptions.SwaggerOptions.ApiTitle ?? throw new ArgumentException($"{nameof(LykkeSwaggerOptions)}.{nameof(LykkeSwaggerOptions.ApiTitle)}"));
 
                 serviceOptions.Swagger?.Invoke(options);
             });

--- a/src/Lykke.Sdk/LykkeServiceOptions.cs
+++ b/src/Lykke.Sdk/LykkeServiceOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -8,13 +9,15 @@ namespace Lykke.Sdk
     public class LykkeServiceOptions<TAppSettings>
     {
         /// <summary>
-        /// Title for Swagger page. Required
+        /// Swagger Options. Required
         /// </summary>
-        public string ApiTitle { get; set; }
+        [Required]
+        public LykkeSwaggerOptions SwaggerOptions { get; set; }
 
         /// <summary>
         /// Logging configuration delegate. Required.
         /// </summary>
+        [Required]
         public Action<LykkeLoggingOptions<TAppSettings>> Logs { get; set; }
 
         /// <summary>

--- a/src/Lykke.Sdk/LykkeSwaggerOptions.cs
+++ b/src/Lykke.Sdk/LykkeSwaggerOptions.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+
+namespace Lykke.Sdk
+{
+    /// <summary>
+    /// Configuration options for swagger.
+    /// </summary>
+    [PublicAPI]
+    public class LykkeSwaggerOptions
+    {
+        /// <summary>Swagger API title, Required</summary>
+        [Required]
+        public string ApiTitle { get; set; }
+
+
+        /// <summary>API version, Required, Default = 'v1'</summary>
+        [Required]
+        public string ApiVersion { get; set; } = "v1";
+    }
+}


### PR DESCRIPTION
Not all services have api version v1 and without documentitle node-js autorest client generation fails.